### PR TITLE
don't end with as_tibble in bake functions

### DIFF
--- a/R/combine_stringdist.R
+++ b/R/combine_stringdist.R
@@ -151,7 +151,7 @@ bake.step_combine_stringdist <- function(object, new_data, ...) {
         object$res[[i]]
       )
   }
-  as_tibble(new_data)
+  new_data
 }
 
 combine_apply <- function(x, dict) {

--- a/R/difftime.R
+++ b/R/difftime.R
@@ -138,7 +138,7 @@ bake.step_difftime <- function(object, new_data, ...) {
                    object$unit)
         )
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/maxabs.R
+++ b/R/maxabs.R
@@ -97,7 +97,7 @@ bake.step_maxabs <- function(object, new_data, ...) {
       object$res[[col_name]]
     )
   }
-  as_tibble(new_data)
+  new_data
 }
 
 maxabs_apply <- function(x, res) {

--- a/R/minmax.R
+++ b/R/minmax.R
@@ -97,7 +97,7 @@ bake.step_minmax <- function(object, new_data, ...) {
       object$res[[col_name]]
     )
   }
-  as_tibble(new_data)
+  new_data
 }
 
 minmax_apply <- function(x, res) {

--- a/R/robust.R
+++ b/R/robust.R
@@ -125,7 +125,7 @@ bake.step_robust <- function(object, new_data, ...) {
       object$res[[col_name]]
     )
   }
-  as_tibble(new_data)
+  new_data
 }
 
 robust_apply <- function(x, res) {

--- a/R/unit_normalize.R
+++ b/R/unit_normalize.R
@@ -96,7 +96,7 @@ bake.step_unit_normalize <- function(object, new_data, ...) {
     norm = object$norm
   )
 
-  as_tibble(new_data)
+  new_data
 }
 
 unit_normalize_apply <- function(x, norm = c("l2", "l1", "max")) {

--- a/R/yeet.R
+++ b/R/yeet.R
@@ -75,7 +75,7 @@ bake.step_yeet <- function(object, new_data, ...) {
   if (length(object$removals) > 0) {
     new_data <- new_data[, !(colnames(new_data) %in% object$removals)]
   }
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export


### PR DESCRIPTION
Since `bake.recipe()` calls `as_tibble()` after each step we don't need to do it inside each step.