### PR TITLE
Update almanac object class

### DIFF
--- a/R/date_after.R
+++ b/R/date_after.R
@@ -195,7 +195,7 @@ prep.step_date_after <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )

--- a/R/date_before.R
+++ b/R/date_before.R
@@ -195,7 +195,7 @@ prep.step_date_before <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )

--- a/R/date_nearest.R
+++ b/R/date_nearest.R
@@ -195,7 +195,7 @@ prep.step_date_nearest <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )

--- a/R/time_event.R
+++ b/R/time_event.R
@@ -87,7 +87,7 @@ prep.step_time_event <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )


### PR DESCRIPTION
This was just the first small obvious thing that I needed to fix in order for any of the four almanac rule based steps to work.

Updates the class inheritance check to match the class currently appearing on almanac objects from "rschedule" to "almanac_rschedule".