### PR TITLE
Update step_time_event's behavior and code style to be more in line with recipe::step_holiday

### DIFF
--- a/R/date_after.R
+++ b/R/date_after.R
@@ -195,7 +195,7 @@ prep.step_date_after <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )

--- a/R/date_before.R
+++ b/R/date_before.R
@@ -195,7 +195,7 @@ prep.step_date_before <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )

--- a/R/date_nearest.R
+++ b/R/date_nearest.R
@@ -195,7 +195,7 @@ prep.step_date_nearest <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )

--- a/R/time_event.R
+++ b/R/time_event.R
@@ -87,7 +87,7 @@ prep.step_time_event <- function(x, training, info = NULL, ...) {
     )
   }
 
-  if (!all(purrr::map_lgl(x$rules, inherits, "rschedule"))) {
+  if (!all(purrr::map_lgl(x$rules, inherits, "almanac_rschedule"))) {
     rlang::abort(
       "All `rules` must be `rschedule`s from {almanac}"
     )

--- a/R/time_event.R
+++ b/R/time_event.R
@@ -122,7 +122,7 @@ bake.step_time_event <- function(object, new_data, ...) {
     )
 
     names(tmp) <- paste(col_name, names(tmp), sep = "_")
-    tmp <- purrr::map_dfc(tmp, vctrs::vec_cast, integer())
+    tmp[] <- lapply(X = tmp, FUN = vctrs::vec_cast, integer())
 
     tmp <- check_name(tmp, new_data, object, names(tmp))
     new_data <- vctrs::vec_cbind(new_data, tmp)
@@ -133,7 +133,7 @@ bake.step_time_event <- function(object, new_data, ...) {
 }
 
 get_time_events <- function(rules, column, name, new_data) {
-  res <- purrr::map(rules, ~ alma_in(new_data[[column]], .x))
+  res <- lapply(X = rules, FUN = \(x) almanac::alma_in(new_data[[column]],x))
   res <- as_tibble(res)
   res
 }

--- a/R/time_event.R
+++ b/R/time_event.R
@@ -4,6 +4,7 @@
 #' create new columns indicating if the date fall on recurrent event.
 #'
 #' @inheritParams recipes::step_center
+#' @inheritParams recipes::step_date
 #' @param rules Named list of `almanac` rules.
 #' @param columns A character string of variables that will be
 #'  used as inputs. This field is a placeholder and will be
@@ -11,6 +12,9 @@
 #' @return An updated version of `recipe` with the new check added to the
 #'  sequence of any existing operations.
 #' @export
+#' @details Unlike some other steps `step_time_event` does *not* remove the
+#' original date variables by default. Set `keep_original_cols` to `FALSE` to
+#' remove them.
 #'
 #' @examples
 #' library(recipes)

--- a/R/time_event.R
+++ b/R/time_event.R
@@ -122,7 +122,7 @@ bake.step_time_event <- function(object, new_data, ...) {
 }
 
 time_event_helper <- function(columnn, name, new_data, rule) {
-  res <- purrr::map_dfc(rule, ~ alma_in(new_data[[columnn]], .x))
+  res <- purrr::map_dfc(rule, ~ as.integer(alma_in(new_data[[columnn]], .x)))
 
   names(res) <- paste(name, names(res), sep = "_")
   res

--- a/man/step_time_event.Rd
+++ b/man/step_time_event.Rd
@@ -11,6 +11,7 @@ step_time_event(
   trained = FALSE,
   rules = list(),
   columns = NULL,
+  keep_original_cols = TRUE,
   skip = FALSE,
   id = rand_id("time_event")
 )
@@ -34,6 +35,9 @@ preprocessing have been estimated.}
 used as inputs. This field is a placeholder and will be
 populated once \code{\link[=prep.recipe]{prep.recipe()}} is used.}
 
+\item{keep_original_cols}{A logical to keep the original variables in the
+output. Defaults to \code{TRUE}.}
+
 \item{skip}{A logical. Should the step be skipped when the
 recipe is baked by \code{\link[recipes:bake]{bake()}}? While all operations are baked
 when \code{\link[recipes:prep]{prep()}} is run, some operations may not be able to be
@@ -50,6 +54,11 @@ sequence of any existing operations.
 \description{
 \code{step_time_event()} creates a \emph{specification} of a recipe step that will
 create new columns indicating if the date fall on recurrent event.
+}
+\details{
+Unlike some other steps \code{step_time_event} does \emph{not} remove the
+original date variables by default. Set \code{keep_original_cols} to \code{FALSE} to
+remove them.
 }
 \examples{
 library(recipes)

--- a/tests/testthat/test-time_event.R
+++ b/tests/testthat/test-time_event.R
@@ -19,14 +19,14 @@ test_that("time_event works", {
 
   res <- bake(rec_spec, new_data = NULL)
 
-  expect_equal(names(res), c("date1_weekend", "date1_weekday"))
+  expect_equal(names(res), c("date1","date1_weekend", "date1_weekday"))
 
   expect_equal(
-    alma_in(examples$date1, on_weekdays),
+    vctrs::vec_cast(alma_in(examples$date1, on_weekdays), integer()),
     res$date1_weekday
   )
   expect_equal(
-    alma_in(examples$date1, on_weekends),
+    vctrs::vec_cast(alma_in(examples$date1, on_weekends), integer()),
     res$date1_weekend
   )
 })
@@ -42,23 +42,24 @@ test_that("time_event works with multiple columns", {
 
   res <- bake(rec_spec, new_data = NULL)
 
-  expect_equal(names(res), c("date1_weekend", "date1_weekday",
+  expect_equal(names(res), c("date1", "date2",
+                             "date1_weekend", "date1_weekday",
                              "date2_weekend", "date2_weekday"))
 
   expect_equal(
-    alma_in(examples$date1, on_weekdays),
+    vctrs::vec_cast(alma_in(examples$date1, on_weekdays), integer()),
     res$date1_weekday
   )
   expect_equal(
-    alma_in(examples$date1, on_weekends),
+    vctrs::vec_cast(alma_in(examples$date1, on_weekends), integer()),
     res$date1_weekend
   )
   expect_equal(
-    alma_in(examples$date2, on_weekdays),
+    vctrs::vec_cast(alma_in(examples$date2, on_weekdays), integer()),
     res$date2_weekday
   )
   expect_equal(
-    alma_in(examples$date2, on_weekends),
+    vctrs::vec_cast(alma_in(examples$date2, on_weekends), integer()),
     res$date2_weekend
   )
 })


### PR DESCRIPTION
Took a pass at updating just this one step to run by you and get feedback. This pull request includes:

- The updated class name for the almanac objects, otherwise nothing works
- Switch to returning integer binary variables rather than boolean, to more closely align with `step_holiday` which I think these steps are most closely related to
- Adds the `keep_original_cols` argument with a default of `TRUE` as in `step_holiday`
- Refactors the `bake` method slightly, again to align with the approach in `step_holiday` and to replace `purrr` functions with `lapply`.
- Updates the tests to align with the modifications above

Basically, I just wanted to take a stab at a single function and get a sense of whether any of this is in the general direction you'd like to see.

